### PR TITLE
Compatibility with older iLO versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM python:2.7-alpine
 ADD . /usr/src/hpilo_exporter
 RUN pip install -e /usr/src/hpilo_exporter
 ENTRYPOINT ["hpilo-exporter"]
-EXPOSE 8080
+EXPOSE 9416

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install -e $HPILO_EXPORTER_DIR
 
 Then just:
 ```
-hpilo-exporter [--address=0.0.0.0 --port=8080 --endpoint="/metrics"]
+hpilo-exporter [--address=0.0.0.0 --port=9100 --endpoint="/metrics"]
 ```
 
 ### Docker
@@ -79,17 +79,17 @@ docker build --rm -t hpilo-exporter .
 
 To run the container
 ```
-docker run -p 8080:8080 hpilo-exporter:latest
+docker run -p 9100:9100 hpilo-exporter:latest
 ```
 
 You can then call the web server on the defined endpoint, `/metrics` by default.
 ```
-curl 'http://127.0.0.1:8080/metrics?ilo_host=127.0.0.1&ilo_port=9018&ilo_user=admin&ilo_password=admin'
+curl 'http://127.0.0.1:9100/metrics?ilo_host=127.0.0.1&ilo_port=9018&ilo_user=admin&ilo_password=admin'
 ```
 
 Passing argument to the docker run command
 ```
-docker run -p 8080:8080 hpilo-exporter:latest --port 8082 --ilo_user my_user --ilo_password my_secret_password
+docker run -p 9100:9100 hpilo-exporter:latest --port 8082 --ilo_user my_user --ilo_password my_secret_password
 ```
 
 ### Docker compose

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ health_at_a_glance:
   processor: {status: OK}
   storage: {status: Degraded}
   temperature: {status: OK}
+  vrm: {status: Ok}
+  drive: {status: Ok}
 ```
 
 The returned output would be:
@@ -39,6 +41,8 @@ hpilo_power_supplies{product_name="ProLiant DL360 Gen9",server_name="name.fqdn.d
 hpilo_processor{product_name="ProLiant DL360 Gen9",server_name="name.fqdn.domain"} 0.0
 hpilo_network{product_name="ProLiant DL360 Gen9",server_name="name.fqdn.domain"} 2.0
 hpilo_temperature{product_name="ProLiant DL360 Gen9",server_name="name.fqdn.domain"} 0.0
+hpilo_vrm{product_name="ProLiant DL380 Gen6",server_name="name.fqdn.domain"} 0.0
+hpilo_drive{product_name="ProLiant DL380 Gen6",server_name="name.fqdn.domain"} 0.0
 hpilo_firmware_version{product_name="ProLiant DL360 Gen9",server_name="name.fqdn.domain"} 2.5
 ```
 
@@ -54,21 +58,14 @@ pip install -e $HPILO_EXPORTER_DIR
 
 Then just:
 ```
-hpilo-exporter [--address=0.0.0.0 --port=9100 --endpoint="/metrics"]
+hpilo-exporter [--address=0.0.0.0 --port=9416 --endpoint="/metrics"]
 ```
 
 ### Docker
 
-Prebuild images are available from our docker repository:
-
-Latest dev build
+Prebuild images are available from the docker repository:
 ```
-idnt/prometheus-exporter-hpilo:dev
-```
-
-Latest stable build
-```
-idnt/prometheus-exporter-hpilo:latest
+idnt/hpilo-exporter:latest
 ```
 
 
@@ -79,17 +76,17 @@ docker build --rm -t hpilo-exporter .
 
 To run the container
 ```
-docker run -p 9100:9100 hpilo-exporter:latest
+docker run -p 9416:9416 hpilo-exporter:latest
 ```
 
 You can then call the web server on the defined endpoint, `/metrics` by default.
 ```
-curl 'http://127.0.0.1:9100/metrics?ilo_host=127.0.0.1&ilo_port=9018&ilo_user=admin&ilo_password=admin'
+curl 'http://127.0.0.1:9416/metrics?ilo_host=127.0.0.1&ilo_port=443&ilo_user=admin&ilo_password=admin'
 ```
 
 Passing argument to the docker run command
 ```
-docker run -p 9100:9100 hpilo-exporter:latest --port 8082 --ilo_user my_user --ilo_password my_secret_password
+docker run -p 9416:9416 hpilo-exporter:latest --port 9416 --ilo_user my_user --ilo_password my_secret_password
 ```
 
 ### Docker compose
@@ -100,19 +97,23 @@ Here is an example of Docker Compose deployment:
 hpilo:
     image: my.registry/hpilo-exporter
     ports:
-      - 8082:8082
+      - 9416:9416
     command:
-      - '--port=8082'
+      - '--port=9416'
     deploy:
       placement:
         constraints:
           - node.hostname == my_node.domain
 ```
 
+### Kubernetes
+
+A helm chart is available at [prometheus-helm-addons](https://github.com/IDNT/prometheus-helm-addons).
+
 ### Prometheus config
 
 Assuming:
-- the exporter is available on `http://hpilo:8082`
+- the exporter is available on `http://hpilo:9416`
 - you use same the port,username and password for all your iLO
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -59,7 +59,20 @@ hpilo-exporter [--address=0.0.0.0 --port=8080 --endpoint="/metrics"]
 
 ### Docker
 
-Build the image
+Prebuild images are available from our docker repository:
+
+Latest dev build
+```
+idnt/prometheus-exporter-hpilo:dev
+```
+
+Latest stable build
+```
+idnt/prometheus-exporter-hpilo:latest
+```
+
+
+To build the image yourself
 ```
 docker build --rm -t hpilo-exporter .
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import io
 from setuptools import setup, find_packages
 
-VERSION = "0.3.3"
+VERSION = "0.3.4"
 PACKAGE_NAME = "hpilo-exporter"
 SOURCE_DIR_NAME = "src"
 

--- a/src/hpilo_exporter/exporter.py
+++ b/src/hpilo_exporter/exporter.py
@@ -84,9 +84,16 @@ class RequestHandler(BaseHTTPRequestHandler):
                 print(e)
 
             # get product and server name
-            product_name = ilo.get_product_name()
-            server_name = ilo.get_server_name()
-
+            try:
+        	product_name = ilo.get_product_name()
+    	    except:
+    		product_name = "Unknown HP Server"
+    		
+    	    try:
+        	server_name = ilo.get_server_name()
+    	    except:
+    		server_name = ""
+	    
             # get health at glance
             health_at_glance = ilo.get_embedded_health()['health_at_a_glance']
             if health_at_glance is not None:
@@ -94,11 +101,10 @@ class RequestHandler(BaseHTTPRequestHandler):
                     for status in value.items():
                         if status[0] == 'status':
                             gauge = 'hpilo_{}_gauge'.format(key)
-
-                            if status[1] == 'OK':
+                            if status[1].upper() == 'OK' or status[1].upper() == "FULLY REDUNDANT":
                                 prometheus_metrics.gauges[gauge].labels(product_name=product_name,
                                                                         server_name=server_name).set(0)
-                            elif status[1] == 'Degraded':
+                            elif status[1].upper() == 'DEGRADED':
                                 prometheus_metrics.gauges[gauge].labels(product_name=product_name,
                                                                         server_name=server_name).set(1)
                             else:

--- a/src/hpilo_exporter/exporter.py
+++ b/src/hpilo_exporter/exporter.py
@@ -96,12 +96,13 @@ class RequestHandler(BaseHTTPRequestHandler):
 	    
             # get health at glance
             health_at_glance = ilo.get_embedded_health()['health_at_a_glance']
+            
             if health_at_glance is not None:
                 for key, value in health_at_glance.items():
                     for status in value.items():
                         if status[0] == 'status':
                             gauge = 'hpilo_{}_gauge'.format(key)
-                            if status[1].upper() == 'OK' or status[1].upper() == "FULLY REDUNDANT":
+                            if status[1].upper() == 'OK':
                                 prometheus_metrics.gauges[gauge].labels(product_name=product_name,
                                                                         server_name=server_name).set(0)
                             elif status[1].upper() == 'DEGRADED':

--- a/src/hpilo_exporter/main.py
+++ b/src/hpilo_exporter/main.py
@@ -11,7 +11,7 @@ def main():
     parser = argparse.ArgumentParser(description='Exports ilo heath_at_a_glance state to Prometheus')
 
     parser.add_argument('--address', type=str, dest='address', default='0.0.0.0', help='address to serve on')
-    parser.add_argument('--port', type=int, dest='port', default='8080', help='port to bind')
+    parser.add_argument('--port', type=int, dest='port', default='9100', help='port to bind')
     parser.add_argument('--endpoint', type=str, dest='endpoint', default='/metrics',
                         help='endpoint where metrics will be published')
 

--- a/src/hpilo_exporter/main.py
+++ b/src/hpilo_exporter/main.py
@@ -11,7 +11,7 @@ def main():
     parser = argparse.ArgumentParser(description='Exports ilo heath_at_a_glance state to Prometheus')
 
     parser.add_argument('--address', type=str, dest='address', default='0.0.0.0', help='address to serve on')
-    parser.add_argument('--port', type=int, dest='port', default='9100', help='port to bind')
+    parser.add_argument('--port', type=int, dest='port', default='9416', help='port to bind')
     parser.add_argument('--endpoint', type=str, dest='endpoint', default='/metrics',
                         help='endpoint where metrics will be published')
 

--- a/src/hpilo_exporter/prometheus_metrics.py
+++ b/src/hpilo_exporter/prometheus_metrics.py
@@ -3,6 +3,8 @@ from prometheus_client import REGISTRY
 
 registry = REGISTRY
 
+hpilo_vrm_gauge = Gauge('hpilo_vrm', 'HP iLO vrm status', ["product_name", "server_name"])
+hpilo_drive_gauge = Gauge('hpilo_drive', 'HP iLO drive status', ["product_name", "server_name"])
 hpilo_battery_gauge = Gauge('hpilo_battery', 'HP iLO battery status', ["product_name", "server_name"])
 hpilo_storage_gauge = Gauge('hpilo_storage', 'HP iLO storage status', ["product_name", "server_name"])
 hpilo_fans_gauge = Gauge('hpilo_fans', 'HP iLO fans status', ["product_name", "server_name"])
@@ -16,6 +18,8 @@ hpilo_temperature_gauge = Gauge('hpilo_temperature', 'HP iLO temperature status'
 hpilo_firmware_version = Gauge('hpilo_firmware_version', 'HP iLO firmware version', ["product_name", "server_name"])
 
 gauges = {
+    'hpilo_vrm_gauge': hpilo_vrm_gauge,
+    'hpilo_drive_gauge': hpilo_drive_gauge,
     'hpilo_battery_gauge': hpilo_battery_gauge,
     'hpilo_storage_gauge': hpilo_storage_gauge,
     'hpilo_fans_gauge': hpilo_fans_gauge,


### PR DESCRIPTION
- Support for iLO version 2 (vrm, drive gauge)
- Updated documentation
- Reserved port form https://github.com/prometheus/prometheus/wiki/Default-port-allocations
- Added link to helm chart
